### PR TITLE
Add link to my blog post

### DIFF
--- a/_activities/studentblogs.md
+++ b/_activities/studentblogs.md
@@ -13,6 +13,10 @@ This is a collection of blog posts from GSoC students who worked with ML4SCI.
 ### Google Summer of Code 2023
 
 <table class="table table-hover table-striped">
+
+  <tr>
+    <td><a href="https://salcc.github.io/blog/gsoc23" target="_blank">"Quantum Transformers" by Marçal Comajoan Cara</a></td>
+  </tr>
   
   <tr>
     <td><a href="https://www.tommago.com/posts/gsoc23/" target="_blank">"Quantum Generative Adversarial Networks for HEP event generation the LHC" by Tom Magorsch</a></td>


### PR DESCRIPTION
Currently, it's still not online, but it will soon be (today or tomorrow), and the link will be the one added here.

Work done as part of Google Summer of Code 2023.