### PR TITLE
Structural fix: update README GSoC section to evergreen and link to verified 2025 archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Machine Learning for Science github site
 ## About ML4SCI
 Machine Learning for Science (ML4Sci) is an open-source organization that brings together modern machine learning techniques and applies them to cutting edge problems in Science, Technology, Engineering, and Math (STEM). 
 
-## ML4SCI in GSoC 2022
-The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/). If you are a student interested in our [projects](https://ml4sci.org/activities/gsoc.html) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](ml4-sci@cern.ch) if you are interested in participating as a project.
+## ML4SCI GSoC Archive and Information
+The ML4Sci open source organization is a consistent participant in the **[Google Summer of Code](https://summerofcode.withgoogle.com/)** program. If you are a student interested in our projects, please check the **[GSoC Project Archive](/gsoc/2025/summary.html)** for detailed ideas and supervisors from the latest cohort. ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](ml4-sci@cern.ch) if you are interested in participating as a project.
 ![GSOC](https://ml4sci.org/images/GSoC/GSoC-icon-192.png)
 
 Please take a look at our [GSoC Page](https://ml4sci.org/activities/gsoc.html) for more details.


### PR DESCRIPTION
This PR implements three small but important maintenance updates for new contributors:

- Structural Improvement: Updated the header (## ML4SCI GSoC Archive...) and opening sentence to be evergreen, resolving the outdated 'GSoC 2022' reference.

- Functional Fix: Consolidated and corrected the broken links for 'projects' and 'ideas page' to point to the verified working 2025 archive page (/gsoc/2025/summary.html).

- Clarity: Ensures all new prospective contributors for 2026 are directed to the most current set of past projects.