### PR TITLE
Add GSoC 2026 section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ The ML4Sci open source organization is participating in the [2022 Google Summer 
 ![GSOC](https://ml4sci.org/images/GSoC/GSoC-icon-192.png)
 
 Please take a look at our [GSoC Page](https://ml4sci.org/activities/gsoc.html) for more details.
+
+## GSoC 2026
+This repository contains information and project ideas for Google Summer of Code 2026.
+Students are encouraged to explore project descriptions and contact mentors early.
+

--- a/_gsocprojects/2026/project_ML4QDM.md
+++ b/_gsocprojects/2026/project_ML4QDM.md
@@ -1,0 +1,6 @@
+## Baseline ML Strategy
+- Perform exploratory data analysis (EDA) to understand detector feature distributions and data quality issues.
+- Begin with classical baseline models such as Logistic Regression, Random Forest, or Gradient Boosting.
+- Address class imbalance using techniques like reweighting or resampling if needed.
+- Evaluate performance using Precision, Recall, F1-score, ROC-AUC, and confusion matrices.
+- Use cross-validation to ensure model robustness across different data-taking periods.


### PR DESCRIPTION
This PR adds a short GSoC 2026 section to improve clarity for students.
I am preparing for GSoC 2026 and welcome feedback.
