### PR TITLE
docs: Update GSoC year from 2022 to 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Machine Learning for Science github site
 
 Machine Learning for Science (ML4Sci) is an open-source organization that brings together modern machine learning techniques and applies them to cutting edge problems in Science, Technology, Engineering, and Math (STEM).
 
-## ML4SCI in GSoC 2022
+## ML4SCI in GSoC 2026
 
-The ML4Sci open source organization is participating in the [2022 Google Summer of Code](https://summerofcode.withgoogle.com/). If you are a student interested in our [projects](https://ml4sci.org/activities/gsoc.html) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](ml4-sci@cern.ch) if you are interested in participating as a project.
+The ML4Sci open source organization is participating in the [2026 Google Summer of Code](https://summerofcode.withgoogle.com/). If you are a student interested in our [projects](https://ml4sci.org/activities/gsoc.html) please check our [ideas page](https://ml4sci.org/gsoc/2022/summary.html). ML4Sci is an umbrella organization that welcomes other projects and organizations related to machine-learning for science. Please contact the admins at [ml4-sci@cern.ch](ml4-sci@cern.ch) if you are interested in participating as a project.
 ![GSOC](https://ml4sci.org/images/GSoC/GSoC-icon-192.png)
 
 Please take a look at our [GSoC Page](https://ml4sci.org/activities/gsoc.html) for more details.


### PR DESCRIPTION
## Description
Updates outdated GSoC year references in README from 2022 to 2026.

## Changes Made
- Updated section header: "ML4SCI in GSoC 2022" → "ML4SCI in GSoC 2026"
- Updated paragraph text: "2022 Google Summer of Code" → "2026 Google Summer of Code"

## Why
Keeps README current for prospective GSoC 2026 applicants visiting the organization.

## Related
- Official ML4SCI GSoC 2026 announcement: https://ml4sci.org/activities/gsoc2025.html